### PR TITLE
fix: UI API called on a background thread swift warnings

### DIFF
--- a/ios/Plugin/SafeAreaPlugin.swift
+++ b/ios/Plugin/SafeAreaPlugin.swift
@@ -10,34 +10,38 @@ public class SafeAreaPlugin: CAPPlugin {
     private let implementation = SafeArea()
 
     @objc func getStatusBarHeight(_ call: CAPPluginCall) {
-        var statusBarHeight: CGFloat = 0
-        if #available(iOS 13.0, *) {
-            let scenes = UIApplication.shared.connectedScenes
-            let windowScene = scenes.first as? UIWindowScene
-            let window = windowScene?.windows.first
-            statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-        } else {
-            statusBarHeight = UIApplication.shared.statusBarFrame.height
+        DispatchQueue.main.async {
+            var statusBarHeight: CGFloat = 0
+            if #available(iOS 13.0, *) {
+                let scenes = UIApplication.shared.connectedScenes
+                let windowScene = scenes.first as? UIWindowScene
+                let window = windowScene?.windows.first
+                statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+            } else {
+                statusBarHeight = UIApplication.shared.statusBarFrame.height
+            }
+            
+            call.resolve([
+                "height": statusBarHeight
+            ])
         }
-
-        call.resolve([
-            "height": statusBarHeight
-        ])
     }
 
     @objc func getSafeAreaInsets(_ call: CAPPluginCall) {
-        let window: UIWindow?
-        if #available(iOS 13.0, *) {
-            window = UIApplication.shared.windows.first
-        } else {
-            window = UIApplication.shared.keyWindow
+        DispatchQueue.main.async {
+            let window: UIWindow?
+            if #available(iOS 13.0, *) {
+                window = UIApplication.shared.windows.first
+            } else {
+                window = UIApplication.shared.keyWindow
+            }
+            
+            call.resolve([
+                "top": window?.safeAreaInsets.top ?? 0,
+                "bottom": window?.safeAreaInsets.bottom ?? 0,
+                "left": window?.safeAreaInsets.left ?? 0,
+                "right": window?.safeAreaInsets.right ?? 0
+            ])
         }
-
-        call.resolve([
-            "top": window?.safeAreaInsets.top ?? 0,
-            "bottom": window?.safeAreaInsets.bottom ?? 0,
-            "left": window?.safeAreaInsets.left ?? 0,
-            "right": window?.safeAreaInsets.right ?? 0
-        ])
     }
 }


### PR DESCRIPTION
This PR closes issue #4 regarding swift warnings calling UI APIs on a background thread

Ex. `Main Thread Checker: UI API called on a background thread: -[UIWindow safeAreaInsets]`

The solution for this was to wrap the lines where we're accessing the UI APIs with `DispatchQueue.main.async`, as also mentioned in original issue.