### PR TITLE
feat: added support for safe-area web component

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ const getSafeAreaInsets = async () => {
 };
 ```
 
+### CSS Variables
+
 Package also exposes CSS variables, for that you need to call `injectCSSVariables` method in your `platform.ready()` function or whenever app System UI visibility is changed
 
 ```typescript
@@ -57,20 +59,97 @@ then you can use them in your CSS files
 }
 ```
 
+### HTML Tag
+
+Other than the above options, you can also use `safe-area` web component exported by the plugin.
+
+#### Angular
+
+For Angular users, you will get an error warning that this web component is unknown to the Angular compiler. This is resolved by modifying the module that declares your component to allow for custom web components.
+
+```ts
+// your-component.module.ts
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+@NgModule({
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+```
+
+then just wrap the part you want to apply safe area padding on with `safe-area` tag as below
+
+```html
+<safe-area>
+  <!-- Other content -->
+</safe-area>
+```
+
+#### Others
+
+You will have to import the plugin in your component in order to make the web component work.
+
+<details>
+<summary>React</summary>
+
+```jsx
+import '@aashu-dubey/capacitor-statusbar-safe-area';
+// or with named import if you're also using other APIs from plugin
+// import { SafeArea } from '@aashu-dubey/capacitor-statusbar-safe-area';
+
+const MyComponent = () => {
+  return (
+    <safe-area>
+      // Other content
+    </safe-area>
+  );
+}
+```
+
+</details>
+
+<details>
+<summary>Vue</summary>
+
+```html
+<template>
+  <safe-area>
+    <!-- Other content -->
+  </safe-area>
+</template>
+
+<script setup lang="ts">
+import '@aashu-dubey/capacitor-statusbar-safe-area';
+// or with named import if you're also using other APIs from plugin
+// import { SafeArea } from '@aashu-dubey/capacitor-statusbar-safe-area';
+</script>
+```
+
+</details>
+
+#### Attributes
+
+There are two attributes, that can be used with the `safe-area` web component to control it's behaviour, `mode` & `edges`.
+
+```html
+<safe-area mode="margin" edges='top,left,right'></safe-area>
+```
+
+more details [here](#safeareahtmlprops).
+
 ## Capacitor version support
 
 | capacitor | plugin version |
 | --------- | -------------- |
-| v4.x      | 1.1.0          |
+| v4.x      | >= 1.1.0          |
 | v3.x      | <= 1.0.1       |
 
 ## API
 
 <docgen-index>
 
-- [`getStatusBarHeight()`](#getstatusbarheight)
-- [`getSafeAreaInsets()`](#getsafeareainsets)
-- [Interfaces](#interfaces)
+* [`getStatusBarHeight()`](#getstatusbarheight)
+* [`getSafeAreaInsets()`](#getsafeareainsets)
+* [Interfaces](#interfaces)
 
 </docgen-index>
 
@@ -87,7 +166,8 @@ Get the Status bar height on Android and iOS, and on Web it returns 0.
 
 **Returns:** <code>Promise&lt;{ height: number; }&gt;</code>
 
----
+--------------------
+
 
 ### getSafeAreaInsets()
 
@@ -99,17 +179,26 @@ Get the Safe area insets for Android and iOS, and on Web it returns 0 for all.
 
 **Returns:** <code>Promise&lt;<a href="#safeareatype">SafeAreaType</a>&gt;</code>
 
----
+--------------------
+
 
 ### Interfaces
 
+
 #### SafeAreaType
 
-| Prop         | Type                |
-| ------------ | ------------------- |
-| **`top`**    | <code>number</code> |
-| **`bottom`** | <code>number</code> |
-| **`left`**   | <code>number</code> |
-| **`right`**  | <code>number</code> |
+| Prop         | Type                | Description                      |
+| ------------ | ------------------- | -------------------------------- |
+| **`top`**    | <code>number</code> | Safe Area inset value at top.    |
+| **`bottom`** | <code>number</code> | Safe Area inset value at bottom. |
+| **`left`**   | <code>number</code> | Safe Area inset value at left.   |
+| **`right`**  | <code>number</code> | Safe Area inset value at right.  |
 
 </docgen-api>
+
+#### SafeAreaHTMLProps
+
+| Prop        | Type                               | Description                                                                                                                                                              |
+| ----------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`mode`**   | <code>'padding' \| 'margin'</code> | Whether to apply safe area insets as `padding` or `margin`. default `padding`.                                                                                                          |
+| **`edges`**  | <code>string</code>                | Specify the edges you want to apply safe area padding on, separated by comma.<br><br>For example, to apply padding only on top, left and right, `edges="top,left,right"`. default to all edges. |

--- a/example/src/js/capacitor-welcome.js
+++ b/example/src/js/capacitor-welcome.js
@@ -58,6 +58,16 @@ window.customElements.define(
       main pre {
         white-space: pre-line;
       }
+      main .footer {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+      main .footer-text {
+        text-align: center;
+        margin: 0px;
+      }
     </style>
     <div>
       <capacitor-welcome-titlebar>
@@ -89,6 +99,10 @@ window.customElements.define(
           <img id="image" style="max-width: 100%">
         </p>
         <h2>Status bar & Safe Area Info</h2>
+
+        <safe-area class="footer" mode="margin" edges="bottom">
+          <p class="footer-text">This footer uses <b>safe-area</b> tag</p>
+        </safe-area>
       </main>
     </div>
     `;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@aashu-dubey/capacitor-statusbar-safe-area@file:..":
-  version "1.0.1"
+  version "1.1.0"
 
 "@capacitor/android@^4.0.0":
   version "4.4.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@capacitor/android": "^4.0.0",
     "@capacitor/core": "^4.0.0",
-    "@capacitor/docgen": "^0.0.18",
+    "@capacitor/docgen": "^0.2.1",
     "@capacitor/ios": "^4.0.0",
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^1.0.1",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -3,6 +3,68 @@ import { Capacitor } from '@capacitor/core';
 import type { SafeAreaType } from './index';
 import { SafeArea } from './index';
 
+class SafeAreaElement extends HTMLElement {
+  mode: 'padding' | 'margin';
+  edges?: string;
+
+  constructor() {
+    super();
+
+    this.mode = 'padding';
+    // Create a shadow root
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.renderElement();
+  }
+
+  static get observedAttributes() {
+    return ['mode', 'edges'];
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    if (oldValue === newValue) {
+      return;
+    }
+    (this as any)[name] = newValue;
+    this.renderElement();
+  }
+
+  async renderElement() {
+    if (this.shadowRoot) {
+      const safeAreaInset = await SafeArea.getSafeAreaInsets();
+
+      const isMargin = this.mode === 'margin';
+      const edges = this.edges?.split(',').map(item => item.trim());
+
+      const insets = {
+        top: edges && !edges?.includes('top') ? 0 : safeAreaInset.top,
+        bottom: edges && !edges?.includes('bottom') ? 0 : safeAreaInset.bottom,
+        left: edges && !edges?.includes('left') ? 0 : safeAreaInset.left,
+        right: edges && !edges?.includes('right') ? 0 : safeAreaInset.right,
+      };
+
+      this.shadowRoot.innerHTML = `
+        <style>
+          #wrapper {
+            ${isMargin ? 'margin' : 'padding'}-top: ${insets.top}px;
+            ${isMargin ? 'margin' : 'padding'}-bottom: ${insets.bottom}px;
+            ${isMargin ? 'margin' : 'padding'}-left: ${insets.left}px;
+            ${isMargin ? 'margin' : 'padding'}-right: ${insets.right}px;
+          }
+        </style>
+        <div id="wrapper">
+          <slot></slot>
+        </div>
+      `;
+    }
+  }
+}
+
+if (!customElements.get('safe-area'))
+  customElements.define('safe-area', SafeAreaElement);
+
 class SafeAreaController {
   async injectCSSVariables(): Promise<void> {
     this.addStatusBarHeight();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,20 +1,47 @@
 export interface SafeAreaPlugin {
   /**
    * Get the Status bar height on Android and iOS, and on Web it returns 0.
-   *
    */
   getStatusBarHeight(): Promise<{ height: number }>;
 
   /**
    * Get the Safe area insets for Android and iOS, and on Web it returns 0 for all.
-   *
    */
   getSafeAreaInsets(): Promise<SafeAreaType>;
 }
 
 export interface SafeAreaType {
+  /**
+   * Safe Area inset value at top.
+   */
   top: number;
+  /**
+   * Safe Area inset value at bottom.
+   */
   bottom: number;
+  /**
+   * Safe Area inset value at left.
+   */
   left: number;
+  /**
+   * Safe Area inset value at right.
+   */
   right: number;
+}
+
+export interface SafeAreaHTMLProps {
+  /**
+   * Whether to apply safe area insets as `padding` or `margin`.
+   *
+   * default `padding`.
+   */
+  mode: 'padding' | 'margin';
+  /**
+   * Specify the edges you want to apply safe area padding on, separated by comma.
+   *
+   * For example, to apply padding only on top, left and right, `edges="top,left,right"`.
+   *
+   * default to all edges.
+   */
+  edges: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { registerPlugin } from '@capacitor/core';
 
 import SafeAreaController from './controller';
-import type { SafeAreaPlugin } from './definitions';
+import type { SafeAreaPlugin, SafeAreaHTMLProps } from './definitions';
 
 const SafeArea = registerPlugin<SafeAreaPlugin>('SafeArea', {
   web: () => import('./web').then(m => new m.SafeAreaWeb()),
@@ -12,3 +12,12 @@ const controller = new SafeAreaController();
 export * from './definitions';
 export { SafeArea };
 export { controller as SafeAreaController };
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace JSX {
+    export interface IntrinsicElements {
+      'safe-area': SafeAreaHTMLProps;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,14 +42,14 @@
   dependencies:
     tslib "^2.1.0"
 
-"@capacitor/docgen@^0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@capacitor/docgen/-/docgen-0.0.18.tgz#95cf7b20c4faf674c9b30365a7d510ebedc482c7"
-  integrity sha512-BVqzrbSi9u5IaKRLlG0H/ZW8M23FDJpH2018RTGVHRn2Yk3na9jOcItBc3r+rYiwgRgAHylNw9Lt7+lWmJBD3Q==
+"@capacitor/docgen@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@capacitor/docgen/-/docgen-0.2.1.tgz#ed9400bd983b56496b7664dd8858e1a4d0c27eaf"
+  integrity sha512-COS5teC6n+EOSaBS7voHnIeIKH7owALnVoI1AhVArIWtBrc1JxSgkUuvLHpti4VGZdXdsrtp4yBPUwGm8WOZKA==
   dependencies:
-    "@types/node" "^14.17.3"
-    colorette "^1.2.2"
-    github-slugger "^1.3.0"
+    "@types/node" "^14.18.0"
+    colorette "^2.0.16"
+    github-slugger "^1.4.0"
     minimist "^1.2.5"
     typescript "~4.2.4"
 
@@ -225,10 +225,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.8.tgz#16d222a58d4363a2a359656dd20b28414de5d265"
   integrity sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==
 
-"@types/node@^14.17.3":
-  version "14.18.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
-  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
+"@types/node@^14.18.0":
+  version "14.18.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.42.tgz#fa39b2dc8e0eba61bdf51c66502f84e23b66e114"
+  integrity sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -488,10 +488,10 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
-  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+colorette@^2.0.16:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -937,7 +937,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-github-slugger@^1.3.0:
+github-slugger@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.5.0.tgz#17891bbc73232051474d68bd867a34625c955f7d"
   integrity sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==


### PR DESCRIPTION
This PR allows an addition way to handle the UI for safe area, using `safe-area` web component exported by the plugin.

It can be used as follows:
```html
<safe-area>
  <!-- Other content -->
</safe-area>
```

It also comes with 2 attributes to control it's behaviour, `mode` and `edges`.
For example, to use safe area insets as element's margin instead of default padding, and to apply only for top, we would write it as follows:
```html
<safe-area mode="margin" edges="top">
  <!-- Other content -->
</safe-area>
```

more details about it's usage can be found in the [readme](https://github.com/Aashu-Dubey/capacitor-statusbar-safe-area/tree/019b1250a7658c6d8c7c5ad6108018943793c498#html-tag).