### PR TITLE
Add support for insets on Android 9 and below

### DIFF
--- a/android/src/main/java/dev/ashu/capacitor/statusbar/safearea/SafeAreaPlugin.java
+++ b/android/src/main/java/dev/ashu/capacitor/statusbar/safearea/SafeAreaPlugin.java
@@ -38,8 +38,10 @@ public class SafeAreaPlugin extends Plugin {
             Resources res = getActivity().getApplicationContext().getResources();
             WindowInsets windowInsets = getActivity().getWindow().getDecorView().getRootWindowInsets();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                if (windowInsets != null) {
+            if (windowInsets != null) {
+                float density = res.getDisplayMetrics().density;
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     final DisplayCutout cutout = windowInsets.getDisplayCutout();
 
                     leftInset = cutout != null ? cutout.getSafeInsetLeft() : 0;
@@ -48,10 +50,15 @@ public class SafeAreaPlugin extends Plugin {
                     bottomInset = cutout != null ? cutout.getSafeInsetBottom() : 0;
 
                     Insets insets = windowInsets.getSystemWindowInsets();
-                    leftInset = Math.max(leftInset, insets.left) / res.getDisplayMetrics().density;
-                    rightInset = Math.max(rightInset, insets.right) / res.getDisplayMetrics().density;
-                    topInset = Math.max(topInset, insets.top) / res.getDisplayMetrics().density;
-                    bottomInset = Math.max(bottomInset, insets.bottom) / res.getDisplayMetrics().density;
+                    leftInset = Math.max(leftInset, insets.left) / density;
+                    rightInset = Math.max(rightInset, insets.right) / density;
+                    topInset = Math.max(topInset, insets.top) / density;
+                    bottomInset = Math.max(bottomInset, insets.bottom) / density;
+                } else {
+                    leftInset = windowInsets.getSystemWindowInsetLeft() / density;
+                    rightInset = windowInsets.getSystemWindowInsetRight() / density;
+                    topInset = windowInsets.getSystemWindowInsetTop() / density;
+                    bottomInset = windowInsets.getSystemWindowInsetBottom() / density;
                 }
             }
         }


### PR DESCRIPTION
Thanks for this really useful plugin! I use it in an app which has both a transparent status bar and navigation bar, so it's very useful to make sure buttons are not hidden under them.

Currently on Android 9 and below, the plugin always returns 0 for all insets, which was causing buttons to be rendered below the status and navigation bars in my app. This is because the insets are only calculated for `Build.VERSION_CODES.Q` and above.

This PR adds an `else` branch to this `if` check to ensure the insets are returned correctly on Android 9 and below. I have tested it in my app, and the height of the transparent status and navigation bars are returned correctly. `getSystemWindowInsets` is only supported on Android 10 and above, but the individual calls like `getSystemWindowInsetTop` are supported down to Android 4.4, which I why I've used those.