### PR TITLE
docs: add missing 'from' import statement for Vue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You will have to import the plugin in your component in order to make the web co
 <summary>React</summary>
 
 ```jsx
-import { registerSafeAreaElement } '@aashu-dubey/capacitor-statusbar-safe-area';
+import { registerSafeAreaElement } from '@aashu-dubey/capacitor-statusbar-safe-area';
 
 registerSafeAreaElement();
 
@@ -128,7 +128,7 @@ const MyComponent = () => {
 </template>
 
 <script setup lang="ts">
-import { registerSafeAreaElement } '@aashu-dubey/capacitor-statusbar-safe-area';
+import { registerSafeAreaElement } from '@aashu-dubey/capacitor-statusbar-safe-area';
 
 registerSafeAreaElement();
 </script>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You also have to register the custom element before using the tag
 ```ts
 // app.component.ts or your-component.ts
 
-import { registerSafeAreaElement } '@aashu-dubey/capacitor-statusbar-safe-area';
+import { registerSafeAreaElement } from '@aashu-dubey/capacitor-statusbar-safe-area';
 
 registerSafeAreaElement();
 ```


### PR DESCRIPTION
This pull request includes a small but important fix to the `README.md` file. The change corrects the import statement for the `registerSafeAreaElement` function in multiple code examples.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84): Corrected the import statement for `registerSafeAreaElement` by adding the missing `from` keyword in the TypeScript, React, and Vue code examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R105) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R131)